### PR TITLE
core: coldplug possible nop_job

### DIFF
--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -3835,6 +3835,7 @@ int unit_add_node_dependency(Unit *u, const char *what, bool wants, UnitDependen
 int unit_coldplug(Unit *u) {
         int r = 0, q;
         char **i;
+        Job *uj = NULL;
 
         assert(u);
 
@@ -3857,8 +3858,9 @@ int unit_coldplug(Unit *u) {
                         r = q;
         }
 
-        if (u->job) {
-                q = job_coldplug(u->job);
+        uj = (u->job) ? u->job : u->nop_job;
+        if (uj) {
+                q = job_coldplug(uj);
                 if (q < 0 && r >= 0)
                         r = q;
         }


### PR DESCRIPTION
When "systemctl daemon-reload" is run at the same time as "systemctl try-start foo", the latter might hang if foo.service is inactive. That's because Unit::nop_job, unlike Unit::job, is not coldplugged in unit_coldplug, which means that the job can never be queued after manager_reload.

The hang can be reproduced by running

    # for ((N=1; N>0; N++)) ; do echo $N ; systemctl daemon-reload ; sleep 3; done
    # for ((N=1; N>0; N++)) ; do echo $N ; systemctl try-start foo.service ; done

in two different terminals, with foo.service written as following:

\# foo.service
[Service]
Type=oneshot
RemainAfterExit=yes
StartLimitInterval=0
ExecStart=/bin/true

This checks whether a unit with no normal jobs has a (deserialized) nop_job; if found, coldplug it as we did for normal jobs.